### PR TITLE
Fix for motion changes not always loading offsets (#4)

### DIFF
--- a/AI_BetterHScenes/AI_BetterHScenes.cs
+++ b/AI_BetterHScenes/AI_BetterHScenes.cs
@@ -572,18 +572,18 @@ namespace AI_BetterHScenes
 
         //-- Save current motion --//
         //-- Set apply offsets --//
-        [HarmonyPostfix, HarmonyPatch(typeof(H_Lookat_dan), "setInfo")]
-        private static void HScene_ChangeMotion(H_Lookat_dan __instance)
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), "setPlay")]
+        private static void HScene_ChangeMotion(ChaControl __instance, string _strAnmName)
         {
-            if (__instance.strPlayMotion == null || useOneOffsetForAllMotions.Value)
+            if (useOneOffsetForAllMotions.Value || __instance == null || __instance.isPlayer == false  || _strAnmName.IsNullOrEmpty())
                 return;
 
-            currentMotion = __instance.strPlayMotion;
+            currentMotion = _strAnmName;
 
             if (applySavedOffsets.Value)
                 shouldApplyOffsets = true;
         }
-        
+
         private static void HScene_StripClothes(bool stripMales, bool stripFemales)
         {
             if (stripMales)

--- a/HS2_BetterHScenes/HS2_BetterHScenes.cs
+++ b/HS2_BetterHScenes/HS2_BetterHScenes.cs
@@ -387,13 +387,13 @@ namespace HS2_BetterHScenes
 
         //-- Save current motion --//
         //-- Set apply offsets --//
-        [HarmonyPostfix, HarmonyPatch(typeof(H_Lookat_dan), "setInfo")]
-        private static void HScene_ChangeMotion(H_Lookat_dan __instance)
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), "setPlay")]
+        private static void HScene_ChangeMotion(ChaControl __instance, string _strAnmName)
         {
-            if (__instance.strPlayMotion == null || useOneOffsetForAllMotions.Value)
+            if (useOneOffsetForAllMotions.Value || __instance == null || __instance.isPlayer == false || _strAnmName.IsNullOrEmpty())
                 return;
 
-            currentMotion = __instance.strPlayMotion;
+            currentMotion = _strAnmName;
 
             if (applySavedOffsets.Value)
                 shouldApplyOffsets = true;


### PR DESCRIPTION
* using ChaControl.setPlay to detect when a motion changes, it is much more reliable than H_LookAtDan.setInfo
* Only loading animations when setPlay is called for the player

Co-authored-by: Mantas-2155X <syenergyy@gmail.com>